### PR TITLE
Non-blocking process execution and request ID tracking

### DIFF
--- a/Public/js/app.js
+++ b/Public/js/app.js
@@ -109,18 +109,15 @@ export class App {
       this.expressionField.clearPatternHighlight();
     });
 
-    this._pendingCounts = {};
     this._reqSeq = 0;
-    this._httpGens = {};
+    this._latestId = {};
 
     this.runner = new Runner();
     this.runner.onready = this.onRunnerReady.bind(this);
     this.runner.onresponse = (response) => {
-      const method = response.method;
-      if (this._pendingCounts[method] > 0) {
-        this._pendingCounts[method]--;
+      if (response.id && response.id !== this._latestId[response.method]) {
+        return;
       }
-      if (this._pendingCounts[method] > 0) return;
       this.onRunnerResponse(response);
     };
 
@@ -278,7 +275,11 @@ export class App {
 
   run() {
     this.showMatchLoading();
+    const id = String(++this._reqSeq);
     const methods = ["parseExpression", "convertToDSL", "match"];
+    for (const method of methods) {
+      this._latestId[method] = id;
+    }
     const params = {
       pattern: this.expressionField.value,
       text: this.patternTestEditor.value,
@@ -287,12 +288,9 @@ export class App {
 
     if (this.runner.isReady) {
       for (const method of methods) {
-        this._pendingCounts[method] =
-          (this._pendingCounts[method] || 0) + 1;
-      }
-      for (const method of methods) {
         this.runner.run({
           method: method,
+          id,
           ...params,
         });
       }
@@ -302,15 +300,15 @@ export class App {
         "Content-Type": "application/json",
       };
       for (const method of methods) {
-        const seq = (this._httpGens[method] = ++this._reqSeq);
         const body = JSON.stringify({
           method: method,
+          id,
           ...params,
         });
         fetch(`/api/rest/${method}`, { method: "POST", headers, body })
           .then((response) => response.json())
           .then((response) => {
-            if (this._httpGens[response.method] === seq) {
+            if (response.id === this._latestId[response.method]) {
               this.onRunnerResponse(response);
             }
           });
@@ -325,19 +323,19 @@ export class App {
   onPatternTestEditorChange() {
     this.showMatchLoading();
     const method = "match";
+    const id = String(++this._reqSeq);
+    this._latestId[method] = id;
     const params = {
       method,
+      id,
       pattern: this.expressionField.value,
       text: this.patternTestEditor.value,
       matchOptions: this.matchOptions.value,
     };
 
     if (this.runner.isReady) {
-      this._pendingCounts[method] =
-        (this._pendingCounts[method] || 0) + 1;
       this.runner.run(params);
     } else {
-      const seq = (this._httpGens[method] = ++this._reqSeq);
       const headers = {
         Accept: "application/json",
         "Content-Type": "application/json",
@@ -346,7 +344,7 @@ export class App {
       fetch(`/api/rest/${method}`, { method: "POST", headers, body })
         .then((response) => response.json())
         .then((response) => {
-          if (this._httpGens[response.method] === seq) {
+          if (response.id === this._latestId[response.method]) {
             this.onRunnerResponse(response);
           }
         });
@@ -357,8 +355,11 @@ export class App {
 
   onDebuggerStepChange() {
     const method = "debug";
+    const id = String(++this._reqSeq);
+    this._latestId[method] = id;
     const params = {
       method,
+      id,
       pattern: document.getElementById("debugger-regex").value,
       text: this.debuggerText.value,
       matchOptions: this.matchOptions.value,
@@ -366,11 +367,8 @@ export class App {
     };
 
     if (this.runner.isReady) {
-      this._pendingCounts[method] =
-        (this._pendingCounts[method] || 0) + 1;
       this.runner.run(params);
     } else {
-      const seq = (this._httpGens[method] = ++this._reqSeq);
       const headers = {
         Accept: "application/json",
         "Content-Type": "application/json",
@@ -379,7 +377,7 @@ export class App {
       fetch(`/api/rest/${method}`, { method: "POST", headers, body })
         .then((response) => response.json())
         .then((response) => {
-          if (this._httpGens[response.method] === seq) {
+          if (response.id === this._latestId[response.method]) {
             this.onRunnerResponse(response);
           }
         });
@@ -387,7 +385,6 @@ export class App {
   }
 
   onRunnerReady() {
-    this._pendingCounts = {};
     const value = this.expressionField.value;
     if (value) {
       this.onExpressionFieldChange();

--- a/Sources/App/Models/ExecRequest.swift
+++ b/Sources/App/Models/ExecRequest.swift
@@ -6,6 +6,7 @@ struct ExecRequest: Codable {
   let text: String
   let matchOptions: [String]
   let step: String?
+  let id: String?
 }
 
 enum RequestMethod: String, Codable {

--- a/Sources/App/Models/ResultResponse.swift
+++ b/Sources/App/Models/ResultResponse.swift
@@ -5,4 +5,5 @@ struct ResultResponse: Content {
   let method: RequestMethod
   let result: String
   let error: String
+  let id: String?
 }

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -8,9 +8,9 @@ func routes(_ app: Application) throws {
 
   app.webSocket("api", "ws") { (req, ws) in
     ws.onBinary { (ws, buffer) in
+      guard let data = buffer.getData(at: 0, length: buffer.readableBytes) else { return }
       Task {
         do {
-          guard let data = buffer.getData(at: 0, length: buffer.readableBytes) else { return }
 
           let decoder = JSONDecoder()
           let request = try decoder.decode(ExecRequest.self, from: data)
@@ -194,6 +194,7 @@ func routes(_ app: Application) throws {
         }
       }
 
+      let syncQueue = DispatchQueue(label: "exec-sync")
       var didTimeout = false
       group.enter()
       process.terminationHandler = { _ in
@@ -203,11 +204,14 @@ func routes(_ app: Application) throws {
       do {
         try process.run()
       } catch {
+        standardOutput.fileHandleForReading.readabilityHandler = nil
+        standardError.fileHandleForReading.readabilityHandler = nil
+        process.terminationHandler = nil
         continuation.resume(throwing: error)
         return
       }
 
-      let timer = DispatchSource.makeTimerSource(queue: .global())
+      let timer = DispatchSource.makeTimerSource(queue: syncQueue)
       timer.schedule(deadline: .now() + timeout)
       timer.setEventHandler {
         if process.isRunning {
@@ -217,7 +221,7 @@ func routes(_ app: Application) throws {
       }
       timer.resume()
 
-      group.notify(queue: .global()) {
+      group.notify(queue: syncQueue) {
         timer.cancel()
 
         if didTimeout {

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -8,256 +8,231 @@ func routes(_ app: Application) throws {
 
   app.webSocket("api", "ws") { (req, ws) in
     ws.onBinary { (ws, buffer) in
-      do {
-        guard let data = buffer.getData(at: 0, length: buffer.readableBytes) else { return }
+      Task {
+        do {
+          guard let data = buffer.getData(at: 0, length: buffer.readableBytes) else { return }
 
-        let decoder = JSONDecoder()
-        let request = try decoder.decode(ExecRequest.self, from: data)
+          let decoder = JSONDecoder()
+          let request = try decoder.decode(ExecRequest.self, from: data)
 
-        let encoder = JSONEncoder()
+          let encoder = JSONEncoder()
+          let response: ResultResponse
 
-        switch request.method {
-        case .parseExpression:
-          let pattern = request.pattern
-          let matchOptions = request.matchOptions
-          let response = try parseExpression(pattern: pattern, matchOptions: matchOptions)
+          switch request.method {
+          case .parseExpression:
+            response = try await parseExpression(pattern: request.pattern, matchOptions: request.matchOptions, id: request.id)
+          case .convertToDSL:
+            response = try await convertToDSL(pattern: request.pattern, matchOptions: request.matchOptions, id: request.id)
+          case .match:
+            response = try await match(pattern: request.pattern, text: request.text, matchOptions: request.matchOptions, id: request.id)
+          case .debug:
+            response = try await debug(pattern: request.pattern, text: request.text, matchOptions: request.matchOptions, step: request.step, id: request.id)
+          }
 
           if let message = String(data: try encoder.encode(response), encoding: .utf8) {
-            ws.send(message)
+            try await ws.send(message)
           }
-        case .convertToDSL:
-          let pattern = request.pattern
-          let matchOptions = request.matchOptions
-          let response = try convertToDSL(pattern: pattern, matchOptions: matchOptions)
-
-          if let message = String(data: try encoder.encode(response), encoding: .utf8) {
-            ws.send(message)
-          }
-        case .match:
-          let pattern = request.pattern
-          let text = request.text
-          let matchOptions = request.matchOptions
-          let response = try match(pattern: pattern, text: text, matchOptions: matchOptions)
-
-          if let message = String(data: try encoder.encode(response), encoding: .utf8) {
-            ws.send(message)
-          }
-        case .debug:
-          let pattern = request.pattern
-          let text = request.text
-          let matchOptions = request.matchOptions
-          let step = request.step
-          let response = try debug(pattern: pattern, text: text, matchOptions: matchOptions, step: step)
-
-          if let message = String(data: try encoder.encode(response), encoding: .utf8) {
-            ws.send(message)
-          }
+        } catch {
+          req.logger.error("\(error)")
         }
-      } catch {
-        req.logger.error("\(error)")
       }
     }
   }
 
-  app.on(.POST, "api", "rest", "parseExpression", body: .collect(maxSize: "1mb")) { (req) -> ResultResponse in
+  app.on(.POST, "api", "rest", "parseExpression", body: .collect(maxSize: "1mb")) { (req) async throws -> ResultResponse in
     guard let request = try? req.content.decode(ExecRequest.self) else {
       throw Abort(.badRequest)
     }
-
-    let pattern = request.pattern
-    let matchOptions = request.matchOptions
-    let response = try parseExpression(pattern: pattern, matchOptions: matchOptions)
-
-    return response
+    return try await parseExpression(pattern: request.pattern, matchOptions: request.matchOptions, id: request.id)
   }
 
-  app.on(.POST, "api", "rest", "convertToDSL", body: .collect(maxSize: "1mb")) { (req) -> ResultResponse in
+  app.on(.POST, "api", "rest", "convertToDSL", body: .collect(maxSize: "1mb")) { (req) async throws -> ResultResponse in
     guard let request = try? req.content.decode(ExecRequest.self) else {
       throw Abort(.badRequest)
     }
-
-    let pattern = request.pattern
-    let matchOptions = request.matchOptions
-    let response = try convertToDSL(pattern: pattern, matchOptions: matchOptions)
-
-    return response
+    return try await convertToDSL(pattern: request.pattern, matchOptions: request.matchOptions, id: request.id)
   }
 
-  app.on(.POST, "api", "rest", "match", body: .collect(maxSize: "1mb")) { (req) -> ResultResponse in
+  app.on(.POST, "api", "rest", "match", body: .collect(maxSize: "1mb")) { (req) async throws -> ResultResponse in
     guard let request = try? req.content.decode(ExecRequest.self) else {
       throw Abort(.badRequest)
     }
-
-    let pattern = request.pattern
-    let text = request.text
-    let matchOptions = request.matchOptions
-    let response = try match(pattern: pattern, text: text, matchOptions: matchOptions)
-
-    return response
+    return try await match(pattern: request.pattern, text: request.text, matchOptions: request.matchOptions, id: request.id)
   }
 
-  app.on(.POST, "api", "rest", "debug", body: .collect(maxSize: "1mb")) { (req) -> ResultResponse in
+  app.on(.POST, "api", "rest", "debug", body: .collect(maxSize: "1mb")) { (req) async throws -> ResultResponse in
     guard let request = try? req.content.decode(ExecRequest.self) else {
       throw Abort(.badRequest)
     }
-
-    let pattern = request.pattern
-    let text = request.text
-    let matchOptions = request.matchOptions
-    let step = request.step
-
-    let response = try debug(pattern: pattern, text: text, matchOptions: matchOptions, step: step)
-
-    return response
+    return try await debug(pattern: request.pattern, text: request.text, matchOptions: request.matchOptions, step: request.step, id: request.id)
   }
 
-  func parseExpression(pattern: String, matchOptions: [String]) throws -> ResultResponse {
+  func parseExpression(pattern: String, matchOptions: [String], id: String?) async throws -> ResultResponse {
     do {
-      let (stdout, stderr) = try exec(command: "ExpressionParser", timeout: 5, arguments: pattern, matchOptions.joined(separator: ","))
-      return ResultResponse(method: .parseExpression, result: stdout, error: stderr)
+      let (stdout, stderr) = try await exec(command: "ExpressionParser", timeout: 5, arguments: pattern, matchOptions.joined(separator: ","))
+      return ResultResponse(method: .parseExpression, result: stdout, error: stderr, id: id)
     } catch is ProcessTimeoutError {
-      return ResultResponse(method: .parseExpression, result: "", error: "Timed out")
+      return ResultResponse(method: .parseExpression, result: "", error: "Timed out", id: id)
     }
   }
 
-  func convertToDSL(pattern: String, matchOptions: [String]) throws -> ResultResponse {
+  func convertToDSL(pattern: String, matchOptions: [String], id: String?) async throws -> ResultResponse {
     do {
-      let (stdout, stderr) = try exec(command: "DSLConverter", timeout: 5, arguments: pattern, matchOptions.joined(separator: ","))
-      return ResultResponse(method: .convertToDSL, result: stdout, error: stderr)
+      let (stdout, stderr) = try await exec(command: "DSLConverter", timeout: 5, arguments: pattern, matchOptions.joined(separator: ","))
+      return ResultResponse(method: .convertToDSL, result: stdout, error: stderr, id: id)
     } catch is ProcessTimeoutError {
-      return ResultResponse(method: .convertToDSL, result: "", error: "Timed out")
+      return ResultResponse(method: .convertToDSL, result: "", error: "Timed out", id: id)
     }
   }
 
-  func match(pattern: String, text: String, matchOptions: [String]) throws -> ResultResponse {
+  func match(pattern: String, text: String, matchOptions: [String], id: String?) async throws -> ResultResponse {
     do {
-      let (stdout, stderr) = try exec(command: "Matcher", timeout: 5, arguments: pattern, text, matchOptions.joined(separator: ","))
-      return ResultResponse(method: .match, result: stdout, error: stderr)
+      let (stdout, stderr) = try await exec(command: "Matcher", timeout: 5, arguments: pattern, text, matchOptions.joined(separator: ","))
+      return ResultResponse(method: .match, result: stdout, error: stderr, id: id)
     } catch is ProcessTimeoutError {
-      return ResultResponse(method: .match, result: "", error: "Timed out")
+      return ResultResponse(method: .match, result: "", error: "Timed out", id: id)
     }
   }
 
-  func debug(pattern: String, text: String, matchOptions: [String], step: String?) throws -> ResultResponse {
-    let context = Debugger.Context()
+  func debug(pattern: String, text: String, matchOptions: [String], step: String?, id: String?) async throws -> ResultResponse {
+    try await withCheckedThrowingContinuation { continuation in
+      DispatchQueue.global().async {
+        do {
+          let context = Debugger.Context()
 
-    func run(pattern: String, text: String, matchingOptions: [String] = [], until step: Int? = nil) throws {
-      context.reset()
-      context.breakPoint = step
+          func run(pattern: String, text: String, matchingOptions: [String] = [], until step: Int? = nil) throws {
+            context.reset()
+            context.breakPoint = step
 
-      let debugger = Debugger()
-      try debugger.run(pattern: pattern, text: text, matchingOptions: matchingOptions, context: context)
-    }
+            let debugger = Debugger()
+            try debugger.run(pattern: pattern, text: text, matchingOptions: matchingOptions, context: context)
+          }
 
-    let breakPoint: Int?
-    if let step {
-      breakPoint = Int(step)
-    } else {
-      breakPoint = nil
-    }
-    try run(pattern: pattern, text: text, matchingOptions: matchOptions)
-    let stepCount = context.stepCount
+          let breakPoint: Int?
+          if let step {
+            breakPoint = Int(step)
+          } else {
+            breakPoint = nil
+          }
+          try run(pattern: pattern, text: text, matchingOptions: matchOptions)
+          let stepCount = context.stepCount
 
-    try run(pattern: pattern, text: text, matchingOptions: matchOptions, until: breakPoint)
+          try run(pattern: pattern, text: text, matchingOptions: matchOptions, until: breakPoint)
 
-    let metrics = Debugger.Metrics(
-      instructions: context.instructions,
-      programCounter: context.programCounter,
-      stepCount: stepCount,
-      step: breakPoint ?? 1,
-      totalCycleCount: context.totalCycleCount,
-      resets: context.resets,
-      backtracks: context.backtracks,
-      traces: [
-        Debugger.Trace(
-          location: Debugger.Location(
-            start: context.start,
-            end: context.current
+          let metrics = Debugger.Metrics(
+            instructions: context.instructions,
+            programCounter: context.programCounter,
+            stepCount: stepCount,
+            step: breakPoint ?? 1,
+            totalCycleCount: context.totalCycleCount,
+            resets: context.resets,
+            backtracks: context.backtracks,
+            traces: [
+              Debugger.Trace(
+                location: Debugger.Location(
+                  start: context.start,
+                  end: context.current
+                )
+              )
+            ],
+            failure: Debugger.Location(start: context.current, end: context.failurePosition),
           )
-        )
-      ],
-      failure: Debugger.Location(start: context.current, end: context.failurePosition),
-    )
-    let data = try JSONEncoder().encode(metrics)
+          let data = try JSONEncoder().encode(metrics)
 
-    let result = String(data: data, encoding: .utf8) ?? ""
-    let response = ResultResponse(method: .debug, result: result, error: "")
+          let result = String(data: data, encoding: .utf8) ?? ""
+          let response = ResultResponse(method: .debug, result: result, error: "", id: id)
 
-    return response
+          continuation.resume(returning: response)
+        } catch {
+          continuation.resume(throwing: error)
+        }
+      }
+    }
   }
 
   struct ProcessTimeoutError: Error {}
 
-  func exec(command: String, timeout: TimeInterval = 5, arguments: String...) throws -> (stdout: String, stderr: String) {
-    let process = Process()
-    let executableURL = URL(
-      fileURLWithPath: app.directory.workingDirectory
-    )
-    .appendingPathComponent(command)
+  func exec(command: String, timeout: TimeInterval = 5, arguments: String...) async throws -> (stdout: String, stderr: String) {
+    try await withCheckedThrowingContinuation { continuation in
+      let process = Process()
+      let executableURL = URL(
+        fileURLWithPath: app.directory.workingDirectory
+      )
+      .appendingPathComponent(command)
 
-    process.executableURL = executableURL
-    process.arguments = arguments
+      process.executableURL = executableURL
+      process.arguments = arguments
 
-    let standardOutput = Pipe()
-    let standardError = Pipe()
-    process.standardOutput = standardOutput
-    process.standardError = standardError
+      let standardOutput = Pipe()
+      let standardError = Pipe()
+      process.standardOutput = standardOutput
+      process.standardError = standardError
 
-    var stdoutData = Data()
-    var stderrData = Data()
-    let group = DispatchGroup()
+      var stdoutData = Data()
+      var stderrData = Data()
+      let group = DispatchGroup()
 
-    group.enter()
-    standardOutput.fileHandleForReading.readabilityHandler = { handle in
-      let chunk = handle.availableData
-      if chunk.isEmpty {
-        standardOutput.fileHandleForReading.readabilityHandler = nil
+      group.enter()
+      standardOutput.fileHandleForReading.readabilityHandler = { handle in
+        let chunk = handle.availableData
+        if chunk.isEmpty {
+          standardOutput.fileHandleForReading.readabilityHandler = nil
+          group.leave()
+        } else {
+          stdoutData.append(chunk)
+        }
+      }
+
+      group.enter()
+      standardError.fileHandleForReading.readabilityHandler = { handle in
+        let chunk = handle.availableData
+        if chunk.isEmpty {
+          standardError.fileHandleForReading.readabilityHandler = nil
+          group.leave()
+        } else {
+          stderrData.append(chunk)
+        }
+      }
+
+      var didTimeout = false
+      group.enter()
+      process.terminationHandler = { _ in
         group.leave()
-      } else {
-        stdoutData.append(chunk)
+      }
+
+      do {
+        try process.run()
+      } catch {
+        continuation.resume(throwing: error)
+        return
+      }
+
+      let timer = DispatchSource.makeTimerSource(queue: .global())
+      timer.schedule(deadline: .now() + timeout)
+      timer.setEventHandler {
+        if process.isRunning {
+          didTimeout = true
+          process.terminate()
+        }
+      }
+      timer.resume()
+
+      group.notify(queue: .global()) {
+        timer.cancel()
+
+        if didTimeout {
+          continuation.resume(throwing: ProcessTimeoutError())
+          return
+        }
+
+        guard let stdout = String(data: stdoutData, encoding: .utf8),
+              let stderr = String(data: stderrData, encoding: .utf8) else {
+          continuation.resume(throwing: Abort(.internalServerError))
+          return
+        }
+
+        continuation.resume(returning: (stdout, stderr))
       }
     }
-
-    group.enter()
-    standardError.fileHandleForReading.readabilityHandler = { handle in
-      let chunk = handle.availableData
-      if chunk.isEmpty {
-        standardError.fileHandleForReading.readabilityHandler = nil
-        group.leave()
-      } else {
-        stderrData.append(chunk)
-      }
-    }
-
-    try process.run()
-
-    var didTimeout = false
-    let timer = DispatchSource.makeTimerSource(queue: .global())
-    timer.schedule(deadline: .now() + timeout)
-    timer.setEventHandler {
-      if process.isRunning {
-        didTimeout = true
-        process.terminate()
-      }
-    }
-    timer.resume()
-
-    group.wait()
-    process.waitUntilExit()
-    timer.cancel()
-
-    if didTimeout {
-      throw ProcessTimeoutError()
-    }
-
-    guard let stdout = String(data: stdoutData, encoding: .utf8) else {
-      throw Abort(.internalServerError)
-    }
-
-    guard let stderr = String(data: stderrData, encoding: .utf8) else {
-      throw Abort(.internalServerError)
-    }
-
-    return (stdout, stderr)
   }
 }


### PR DESCRIPTION
## Summary
- `exec()` を `group.wait()` / `waitUntilExit()` から `withCheckedThrowingContinuation` + `group.notify` + `terminationHandler` に変更し、イベントループをブロックしないように修正。ヘルスチェックのタイムアウト問題を解消
- 全ルートハンドラを `async` 化、WebSocket `onBinary` を `Task { }` で並列処理に変更
- `ExecRequest` / `ResultResponse` に `id` フィールドを追加し、サーバーがリクエストIDをエコーバック
- フロントエンドのstaleレスポンス検出をペンディングカウント方式からリクエストID方式に変更。並列処理でレスポンスが到着順不同でも正しく動作

## Test plan
- [ ] ヘルスチェック (`/health`, `/healthz`) が遅いregexの処理中でも5秒以内に応答することを確認
- [ ] 連続するドット (`...`) などを素早く入力し、パーサー結果・DSL・マッチ結果が最新の入力に対して正しく表示されることを確認
- [ ] タイムアウトするregexを入力後に編集し、"Timed out" / "no match" が正しく表示されることを確認
- [ ] デバッガーモーダルでステップ操作が正常に動作することを確認
- [ ] WebSocket未接続時のHTTPフォールバックが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)