### PR TITLE
Fix tooltip descriptions for all regex syntax elements

### DIFF
--- a/Public/js/docs/reference.js
+++ b/Public/js/docs/reference.js
@@ -117,58 +117,67 @@ const references = {
     },
 
     binary: {
-      title: "Unicode property escapes",
+      title: "Unicode property",
       detail:
-        "Allows for matching characters based on their Unicode properties.",
+        "Matches any character with the '{{value}}' Unicode binary property.",
     },
     script: {
-      title: "Script",
-      detail: "No overview available.",
+      title: "Unicode script",
+      detail: "Matches any character in the '{{value}}' Unicode script.",
     },
     scriptextension: {
-      title: "Script extension",
-      detail: "No overview available.",
+      title: "Unicode script extension",
+      detail:
+        "Matches any character in the '{{value}}' Unicode script extension.",
     },
     named: {
-      title: "Named",
-      detail: "No overview available.",
+      title: "Named character property",
+      detail:
+        "Matches any character with the Unicode name matching '{{value}}'.",
     },
     numerictype: {
       title: "Numeric type",
-      detail: "No overview available.",
+      detail:
+        "Matches any character with the Unicode numeric type '{{value}}'.",
     },
     numericvalue: {
       title: "Numeric value",
-      detail: "No overview available.",
+      detail:
+        "Matches any character with the Unicode numeric value '{{value}}'.",
     },
     mapping: {
-      title: "Mapping",
-      detail: "No overview available.",
+      title: "Character mapping",
+      detail:
+        "Matches any character with the specified Unicode character mapping ({{value}}).",
     },
     ccc: {
-      title: "Custom character class",
-      detail: "No overview available.",
+      title: "Canonical combining class",
+      detail:
+        "Matches any character with the canonical combining class '{{value}}'.",
     },
     age: {
-      title: "Age",
-      detail: "No overview available.",
+      title: "Unicode age",
+      detail:
+        "Matches any character assigned in Unicode version {{value}} or earlier.",
     },
     block: {
-      title: "Block",
-      detail: "No overview available.",
+      title: "Unicode block",
+      detail: "Matches any character in the '{{value}}' Unicode block.",
     },
     pcrespecial: {
-      title: "PCRE special",
-      detail: "No overview available.",
+      title: "PCRE special property",
+      detail:
+        "Matches any character with the PCRE special property '{{value}}'.",
     },
     javaspecial: {
-      title: "Java special",
-      detail: "No overview available.",
+      title: "Java special property",
+      detail:
+        "Matches any character with the Java special property '{{value}}'.",
     },
 
     graphemecluster: {
       title: "Grapheme cluster",
-      detail: "No overview available.",
+      detail: "Matches any single extended Unicode grapheme cluster.",
     },
     trueanychar: {
       title: "Any character",
@@ -183,28 +192,30 @@ const references = {
       detail: "Text segment non-boundary",
     },
     keyboardcontrol: {
-      title: "Control char",
-      detail: "No overview available.",
+      title: "Control character",
+      detail: "Matches the control character <code>{{value}}</code>.",
     },
     keyboardmeta: {
-      title: "Meta",
-      detail: "No overview available.",
+      title: "Meta character",
+      detail: "Matches the meta character <code>{{value}}</code>.",
     },
     keyboardmetacontrol: {
-      title: "Meta control char",
-      detail: "No overview available.",
+      title: "Meta-control character",
+      detail: "Matches the meta-control character <code>{{value}}</code>.",
     },
     namedcharacter: {
       title: "Named character",
-      detail: "No overview available.",
+      detail: "Matches the Unicode character named '{{value}}'.",
     },
     subpattern: {
       title: "Subpattern",
-      detail: "No overview available.",
+      detail:
+        "Matches the same text as the specified subpattern by re-executing its pattern.",
     },
     callout: {
       title: "Callout",
-      detail: "No overview available.",
+      detail:
+        "Calls out to an external function during matching for debugging or advanced logic.",
     },
 
     accept: {
@@ -217,7 +228,8 @@ const references = {
     },
     mark: {
       title: "Backtracking control",
-      detail: "No overview available.",
+      detail:
+        "Sets a mark name for use with other backtracking control verbs.",
     },
     commit: {
       title: "Backtracking control",
@@ -383,7 +395,7 @@ const references = {
 
     absentfunction: {
       title: "Absent function",
-      detail: "No overview available.",
+      detail: "Matches text that does not contain a specified pattern.",
     },
   },
 
@@ -419,25 +431,29 @@ const references = {
         "Keep text matched so far out of the returned match, essentially discarding the match up to this point.",
     },
     nonatomicposlookahead: {
-      title: "Non-atomic Positive lookahead",
-      detail: "No overview available.",
+      title: "Non-atomic positive lookahead",
+      detail:
+        "Like a positive lookahead, but allows backtracking into the lookahead expression.",
     },
     nonatomicposlookbehind: {
-      title: "Non-atomic Positive lookbehind",
-      detail: "No overview available.",
+      title: "Non-atomic positive lookbehind",
+      detail:
+        "Like a positive lookbehind, but allows backtracking into the lookbehind expression.",
     },
 
     scriptrun: {
       title: "Script run",
-      detail: "No overview available.",
+      detail:
+        "Matches a sequence of characters that all belong to the same Unicode script.",
     },
     atomicscriptrun: {
       title: "Atomic script run",
-      detail: "No overview available.",
+      detail:
+        "Atomic (no-backtrack) matching where matched text must all belong to the same Unicode script.",
     },
     changematchingoptions: {
       title: "Change matching options",
-      detail: "No overview available.",
+      detail: "Changes matching options for the enclosed group.",
     },
   },
 
@@ -512,7 +528,7 @@ const references = {
 
     interpolation: {
       title: "Interpolation",
-      detail: "No overview available.",
+      detail: "Embeds the result of an expression into the regex pattern.",
     },
   },
 
@@ -665,11 +681,12 @@ const references = {
 
     any: {
       title: "Any",
-      detail: "No overview available.",
+      detail:
+        "Matches any character that has at least one Unicode property value.",
     },
     assigned: {
       title: "Assigned",
-      detail: "No overview available.",
+      detail: "Matches any assigned Unicode code point.",
     },
     ascii: {
       title: "Unicode property",
@@ -714,7 +731,7 @@ const references = {
   empty: {
     empty: {
       title: "Empty",
-      detail: "No overview available.",
+      detail: "An empty alternative that matches zero-length text.",
     },
   },
 };

--- a/Public/js/docs/reference.js
+++ b/Public/js/docs/reference.js
@@ -185,7 +185,7 @@ const references = {
     },
     textsegment: {
       title: "Text segment",
-      detail: `Equivalent to (?>\O(?:\Y\O)*)`,
+      detail: "Equivalent to (?>\\O(?:\\Y\\O)*)",
     },
     nottextsegment: {
       title: "Not text segment",
@@ -237,7 +237,7 @@ const references = {
     },
     prune: {
       title: "Backtracking control",
-      detail: `acktracking cannot cross (*PRUNE). In simple cases, the use of (*PRUNE) is just an alternative to an atomic group or possessive quantifier, but there are some uses of (*PRUNE) that cannot be expressed in any other way.`,
+      detail: `Backtracking cannot cross (*PRUNE). In simple cases, the use of (*PRUNE) is just an alternative to an atomic group or possessive quantifier, but there are some uses of (*PRUNE) that cannot be expressed in any other way.`,
     },
     skip: {
       title: "Backtracking control",
@@ -246,6 +246,11 @@ const references = {
     then: {
       title: "Backtracking control",
       detail: `This verb causes a skip to the next alternation if the rest of the pattern does not match. That is, it cancels pending backtracking, but only within the current alternation.`,
+    },
+
+    invalid: {
+      title: "Invalid property",
+      detail: "Unrecognized or invalid Unicode property expression.",
     },
   },
 
@@ -290,10 +295,6 @@ const references = {
       detail: "Matches the end position of the previous match.",
     },
 
-    invalid: {
-      title: "Invalid character class",
-      detail: "No overview available.",
-    },
   },
 
   escchars: {

--- a/Sources/ExpressionParser/ExpressionParser.swift
+++ b/Sources/ExpressionParser/ExpressionParser.swift
@@ -440,7 +440,7 @@ struct ExpressionParser {
               end: quant.amount.location.end.utf16Offset(in: pattern)
             )
           ),
-          tooltip: Tooltip(category: "quants", key: "lazy")
+          tooltip: Tooltip(category: "quants", key: "lazy", substitution: ["{{getLazy()}}": "lazy", "{{getLazyFew()}}": "few"])
         )
       )
     case .possessive:

--- a/Sources/ExpressionParser/ExpressionParser.swift
+++ b/Sources/ExpressionParser/ExpressionParser.swift
@@ -1095,7 +1095,7 @@ struct ExpressionParser {
         key = "commit"
       case .prune:
         category = "charclasses"
-        key = "skip"
+        key = "prune"
       case .skip:
         category = "charclasses"
         key = "skip"

--- a/Sources/ExpressionParser/ExpressionParser.swift
+++ b/Sources/ExpressionParser/ExpressionParser.swift
@@ -144,14 +144,33 @@ struct ExpressionParser {
       category = "lookaround"
       key = "nonatomicposlookbehind"
     case .scriptRun:
-      category = "Script run. "
-      key = ""
+      category = "lookaround"
+      key = "scriptrun"
     case .atomicScriptRun:
-      category = "Atomic script run. "
-      key = ""
-    case .changeMatchingOptions(_):
-      category = "Change matching options"
-      key = ""
+      category = "lookaround"
+      key = "atomicscriptrun"
+    case .changeMatchingOptions(let opts):
+      category = "other"
+      key = "mode"
+      var modeSet = Set<AST.MatchingOption>()
+      let modeRemoving = opts.removing.filter { modeSet.insert($0).inserted }
+      modeSet = Set<AST.MatchingOption>()
+      let modeAdding = opts.adding.filter { modeSet.insert($0).inserted }.filter { !modeRemoving.contains($0) }
+      let modeEnable = modeAdding.map { String(pattern[$0.location.range]) }
+      let modeDisable = modeRemoving.map { String(pattern[$0.location.range]) }
+      var modeDesc = ""
+      if !modeEnable.isEmpty {
+        let descs = modeEnable.map { ExpressionParser.flagDescription($0) }
+        modeDesc += " Enables \(descs.joined(separator: ", "))."
+      }
+      if !modeDisable.isEmpty {
+        let descs = modeDisable.map { ExpressionParser.flagDescription($0) }
+        modeDesc += " Disables \(descs.joined(separator: ", "))."
+      }
+      substitution = [
+        "{{~getDesc()}}": "Changes matching options for the enclosed group.",
+        "{{~getModes()}}": modeDesc,
+      ]
     }
 
     // Content
@@ -508,6 +527,7 @@ struct ExpressionParser {
     switch atom.kind {
     case .char(let c):
       let charcode = c.unicodeScalars.map { String(format: "U+%X", $0.value) }.joined(separator: " ")
+      let charName = ExpressionParser.charDisplayName(c)
 
       let value = String(pattern[atom.location.range])
       if value.hasPrefix("\\") {
@@ -515,7 +535,7 @@ struct ExpressionParser {
         category = "misc"
         key = "escchar"
         substitution = [
-          "{{getChar()}}": #""\#(c)""#,
+          "{{getChar()}}": charName,
           "{{code}}": charcode,
           "{{getInsensitive()}}": "Case \(modes.i ? "in" : "")sensitive",
         ]
@@ -524,17 +544,23 @@ struct ExpressionParser {
         category = "misc"
         key = "char"
         substitution = [
-          "{{getChar()}}": #""\#(c)""#,
+          "{{getChar()}}": charName,
           "{{code}}": charcode,
           "{{getInsensitive()}}": "Case \(modes.i ? "in" : "")sensitive",
         ]
       }
     case .scalar(let scalar):
+      let scalarName: String
+      if let name = ExpressionParser.nonprintingCharNames[scalar.value.value] {
+        scalarName = name
+      } else {
+        scalarName = #""\#(String(scalar.value))""#
+      }
       `class` = "char"
       category = "misc"
       key = "char"
       substitution = [
-        "{{getChar()}}": #""\#(String(scalar.value))""#,
+        "{{getChar()}}": scalarName,
         "{{code}}": String(format: "U+%X", scalar.value.value),
         "{{getInsensitive()}}": "Case \(modes.i ? "in" : "")sensitive",
       ]
@@ -647,7 +673,7 @@ struct ExpressionParser {
         category = "charclasses"
         key = "unicodecat"
         substitution = ["{{getUniCat()}}": uniCat]
-      case .binary(let property, let value):
+      case .binary(let property, _):
         switch property {
         case .asciiHexDigit:
           break
@@ -786,33 +812,43 @@ struct ExpressionParser {
         }
         category = "charclasses"
         key = "binary"
-      case .script(_):
+        substitution = ["{{value}}": "\(property)"]
+      case .script(let script):
         category = "charclasses"
         key = "script"
-      case .scriptExtension(_):
+        substitution = ["{{value}}": "\(script)"]
+      case .scriptExtension(let scriptExt):
         category = "charclasses"
         key = "scriptextension"
-      case .named(_):
+        substitution = ["{{value}}": "\(scriptExt)"]
+      case .named(let name):
         category = "charclasses"
         key = "named"
-      case .numericType(_):
+        substitution = ["{{value}}": "\(name)"]
+      case .numericType(let numType):
         category = "charclasses"
         key = "numerictype"
-      case .numericValue(_):
+        substitution = ["{{value}}": "\(numType)"]
+      case .numericValue(let numValue):
         category = "charclasses"
         key = "numericvalue"
-      case .mapping(_, _):
+        substitution = ["{{value}}": "\(numValue)"]
+      case .mapping(let mappingType, let mappingValue):
         category = "charclasses"
         key = "mapping"
-      case .ccc(_):
+        substitution = ["{{value}}": "\(mappingType)=\(mappingValue)"]
+      case .ccc(let combiningClass):
         category = "charclasses"
         key = "ccc"
+        substitution = ["{{value}}": "\(combiningClass)"]
       case .age(let major, let minor):
         category = "charclasses"
         key = "age"
-      case .block(_):
+        substitution = ["{{value}}": "\(major).\(minor)"]
+      case .block(let block):
         category = "charclasses"
         key = "block"
+        substitution = ["{{value}}": "\(block)"]
       case .posix(let property):
         switch property {
         case .alnum:
@@ -831,12 +867,14 @@ struct ExpressionParser {
         category = "charclasses"
         key = "posixcharclass"
         substitution = ["{{value}}": "\(property)"]
-      case .pcreSpecial(_):
-        category = "pcreSpecial"
+      case .pcreSpecial(let pcre):
+        category = "charclasses"
         key = "pcrespecial"
-      case .javaSpecial(_):
-        category = "javaSpecial"
+        substitution = ["{{value}}": "\(pcre)"]
+      case .javaSpecial(let java):
+        category = "charclasses"
         key = "javaspecial"
+        substitution = ["{{value}}": "\(java)"]
       case .invalid(key: let k, value: let v):
         category = "charclasses"
         key = "invalid"
@@ -927,9 +965,10 @@ struct ExpressionParser {
         category = "charclasses"
         key = "notword"
       case .backspace:
-        `class` = "anchor"
-        category = "charclasses"
-        key = "wordboundary"
+        `class` = "esc"
+        category = "misc"
+        key = "escchar"
+        substitution = ["{{getChar()}}": "BACKSPACE", "{{code}}": "(0x08)"]
       case .graphemeCluster:
         `class` = "charclass"
         category = "charclasses"
@@ -964,33 +1003,37 @@ struct ExpressionParser {
         key = "keepout"
       case .trueAnychar:
         `class` = "charclass"
-        category = "charclass"
+        category = "charclasses"
         key = "trueanychar"
       case .textSegment:
         `class` = "charclass"
-        category = "charclass"
+        category = "charclasses"
         key = "textsegment"
       case .notTextSegment:
         `class` = "charclass"
-        category = "charclass"
+        category = "charclasses"
         key = "nottextsegment"
       }
     case .keyboardControl(_):
       `class` = "charclass"
-      category = "charclass"
+      category = "charclasses"
       key = "keyboardcontrol"
+      substitution = ["{{value}}": String(pattern[atom.location.range])]
     case .keyboardMeta(_):
       `class` = "charclass"
-      category = "charclass"
+      category = "charclasses"
       key = "keyboardmeta"
+      substitution = ["{{value}}": String(pattern[atom.location.range])]
     case .keyboardMetaControl(_):
       `class` = "charclass"
-      category = "charclass"
+      category = "charclasses"
       key = "keyboardmetacontrol"
-    case .namedCharacter(_):
+      substitution = ["{{value}}": String(pattern[atom.location.range])]
+    case .namedCharacter(let charName):
       `class` = "charclass"
-      category = "charclass"
+      category = "charclasses"
       key = "namedcharacter"
+      substitution = ["{{value}}": "\(charName)"]
     case .dot:
       `class` = "charclass"
       category = "charclasses"
@@ -1039,25 +1082,25 @@ struct ExpressionParser {
 
       switch directive.kind.value {
       case .accept:
-        category = "charclass"
+        category = "charclasses"
         key = "accept"
       case .fail:
-        category = "charclass"
+        category = "charclasses"
         key = "fail"
       case .mark:
-        category = "charclass"
+        category = "charclasses"
         key = "mark"
       case .commit:
-        category = "charclass"
+        category = "charclasses"
         key = "commit"
       case .prune:
-        category = "charclass"
+        category = "charclasses"
         key = "skip"
       case .skip:
-        category = "charclass"
+        category = "charclasses"
         key = "skip"
       case .then:
-        category = "charclass"
+        category = "charclasses"
         key = "then"
       }
     case .changeMatchingOptions(let matchingOptionSequence):
@@ -1067,14 +1110,16 @@ struct ExpressionParser {
       set = Set<AST.MatchingOption>()
       let adding = matchingOptionSequence.adding.filter { set.insert($0).inserted }.filter { !removing.contains($0) }
 
-      let enable = adding.map { pattern[$0.location.range] }
-      let disable = removing.map { pattern[$0.location.range] }
+      let enable = adding.map { String(pattern[$0.location.range]) }
+      let disable = removing.map { String(pattern[$0.location.range]) }
       var modes = ""
       if !enable.isEmpty {
-        modes += #" Enable "\#(enable.joined())"."#
+        let descs = enable.map { ExpressionParser.flagDescription($0) }
+        modes += " Enables \(descs.joined(separator: ", "))."
       }
       if !disable.isEmpty {
-        modes += #" Disable "\#(disable.joined())"."#
+        let descs = disable.map { ExpressionParser.flagDescription($0) }
+        modes += " Disables \(descs.joined(separator: ", "))."
       }
 
       `class` = "special"
@@ -1387,6 +1432,64 @@ struct ExpressionParser {
         tooltip: Tooltip(category: "empty", key: "empty")
       )
     )
+  }
+
+  private static let nonprintingCharNames: [UInt32: String] = [
+    0x00: "NULL",
+    0x01: "SOH",
+    0x02: "STX",
+    0x03: "ETX",
+    0x04: "EOT",
+    0x05: "ENQ",
+    0x06: "ACK",
+    0x07: "BELL",
+    0x08: "BACKSPACE",
+    0x09: "TAB",
+    0x0A: "LINE FEED",
+    0x0B: "VERTICAL TAB",
+    0x0C: "FORM FEED",
+    0x0D: "CARRIAGE RETURN",
+    0x0E: "SHIFT OUT",
+    0x0F: "SHIFT IN",
+    0x10: "DLE",
+    0x11: "DC1",
+    0x12: "DC2",
+    0x13: "DC3",
+    0x14: "DC4",
+    0x15: "NAK",
+    0x16: "SYN",
+    0x17: "ETB",
+    0x18: "CAN",
+    0x19: "EM",
+    0x1A: "SUB",
+    0x1B: "ESCAPE",
+    0x1C: "FS",
+    0x1D: "GS",
+    0x1E: "RS",
+    0x1F: "US",
+    0x7F: "DELETE",
+  ]
+
+  private static func charDisplayName(_ c: Character) -> String {
+    if let scalar = c.unicodeScalars.first, c.unicodeScalars.count == 1,
+       let name = nonprintingCharNames[scalar.value] {
+      return name
+    }
+    return #""\#(c)""#
+  }
+
+  private static func flagDescription(_ flag: String) -> String {
+    switch flag {
+    case "i": return "case-insensitive matching"
+    case "m": return "multiline mode"
+    case "s": return "single-line mode (dot matches newlines)"
+    case "x": return "extended mode (ignore whitespace)"
+    case "n": return "named captures only"
+    case "J": return "allow duplicate named groups"
+    case "U": return "ungreedy quantifiers by default"
+    case "w": return "Unicode word boundaries"
+    default: return "flag \"\(flag)\""
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Display human-readable names for control characters (e.g. `\x0b` shows "VERTICAL TAB" instead of garbled characters, `\x0c` shows "FORM FEED", `\x0e` shows "SHIFT OUT", etc.)
- Fix inline flag descriptions: `(?i)` now shows "Enables case-insensitive matching" instead of `Enable "i"`, and `(?i:...)` group variant describes the enclosed scope
- Replace all "No overview available." placeholders with proper descriptions for Unicode properties (`\p{Script=Katakana}`, `\p{Block=...}`, `\p{Age=...}`, binary properties, etc.), script runs, non-atomic lookarounds, and other elements
- Fix category typos (`"charclass"` → `"charclasses"`) that caused tooltip lookups to silently fail for backtracking directives, keyboard control chars, text segments, and others
- Fix wrong reference categories (`"pcreSpecial"`/`"javaSpecial"` → `"charclasses"`) so those tooltips resolve correctly
- Pass substitution values from the Swift backend for all dynamic tooltip entries (Unicode script, block, age, binary properties, named characters, CCC, etc.)
- Fix `\b` inside character classes (backspace) being mislabeled as "word boundary" — now correctly shows "BACKSPACE character (0x08)"

## Test plan
- [ ] Hover over `\x0b`, `\x0c`, `\x0e` — should show "VERTICAL TAB", "FORM FEED", "SHIFT OUT" respectively
- [ ] Hover over `(?i)` — should show "Enables case-insensitive matching"
- [ ] Hover over `(?i:...)` — should show "Changes matching options for the enclosed group. Enables case-insensitive matching."
- [ ] Hover over `\p{Script=Katakana}` — should show "Matches any character in the '...' Unicode script"
- [ ] Hover over `\p{Alphabetic}` — should show the binary property name
- [ ] Hover over `(*ACCEPT)`, `(*FAIL)` etc. — should show backtracking control descriptions
- [ ] Verify no tooltip shows "No overview available." for any supported syntax element

🤖 Generated with [Claude Code](https://claude.com/claude-code)