### PR TITLE
Enable debugger for non-matching and timed-out patterns

### DIFF
--- a/Public/js/app.js
+++ b/Public/js/app.js
@@ -259,6 +259,10 @@ export class App {
 
   onExpressionFieldChange() {
     if (!this.expressionField.value) {
+      const id = String(++this._reqSeq);
+      for (const method of ["parseExpression", "convertToDSL", "match"]) {
+        this._latestId[method] = id;
+      }
       this.expressionField.tokens = [];
       this.expressionField.error = null;
       this.dslView.value = "";

--- a/Public/js/app.js
+++ b/Public/js/app.js
@@ -269,6 +269,8 @@ export class App {
       this.dslView.error = null;
       this.dslView.sourceMap = [];
       this.updateMatchCount(0, "match-count");
+      this.patternTestEditor.matches = [];
+      this.patternTestEditor.error = null;
       document.getElementById("debugger-button").disabled = true;
       return;
     }
@@ -456,6 +458,9 @@ export class App {
             document.getElementById("match-count").textContent = "Timed out";
           } else {
             this.updateMatchCount(0, "match-count");
+          }
+          if (response.error && response.error !== "Timed out") {
+            document.getElementById("debugger-button").disabled = true;
           }
         }
 

--- a/Public/js/app.js
+++ b/Public/js/app.js
@@ -265,6 +265,7 @@ export class App {
       this.dslView.error = null;
       this.dslView.sourceMap = [];
       this.updateMatchCount(0, "match-count");
+      document.getElementById("debugger-button").disabled = true;
       return;
     }
 
@@ -400,6 +401,7 @@ export class App {
         } else {
           this.expressionField.tokens = [];
         }
+        const debuggerButton = document.getElementById("debugger-button");
         if (response.error) {
           try {
             const error = JSON.parse(response.error);
@@ -409,8 +411,10 @@ export class App {
           } catch (e) {
             this.expressionField.error = response.error;
           }
+          debuggerButton.disabled = true;
         } else {
           this.expressionField.error = null;
+          debuggerButton.disabled = !response.result;
         }
         break;
       case "convertToDSL":
@@ -438,14 +442,10 @@ export class App {
         }
         break;
       case "match":
-        const debuggerButton = document.getElementById("debugger-button");
-
         if (response.result) {
           const matches = JSON.parse(response.result);
           this.patternTestEditor.matches = matches;
           this.updateMatchCount(matches.length, "match-count");
-
-          debuggerButton.disabled = matches.length === 0;
         } else {
           this.patternTestEditor.matches = [];
           if (response.error === "Timed out") {
@@ -453,8 +453,6 @@ export class App {
           } else {
             this.updateMatchCount(0, "match-count");
           }
-
-          debuggerButton.disabled = true;
         }
 
         this.patternTestEditor.error =


### PR DESCRIPTION
## Summary
- Move debugger button enable/disable logic from the `match` response handler to the `parseExpression` response handler
- The debugger is now available whenever the pattern is syntactically valid, regardless of whether it produces matches
- Previously the debugger was only accessible when `matches.length > 0`, even though the backend already tracked execution steps for non-matching cases
- Also disable the debugger button when the expression field is cleared

## Test plan
- [ ] Enter a valid pattern that matches the test text → debugger button is enabled
- [ ] Enter a valid pattern that does NOT match the test text → debugger button is still enabled
- [ ] Enter a pattern that times out → debugger button is still enabled
- [ ] Enter an invalid pattern (e.g. `[a-z`) → debugger button is disabled
- [ ] Clear the expression field → debugger button is disabled
- [ ] Open the debugger for a non-matching pattern → step through execution to observe the engine's search and failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)