### PR TITLE
Add match results tooltip and fix debugger issues

### DIFF
--- a/Public/css/common.css
+++ b/Public/css/common.css
@@ -49,6 +49,10 @@
 .button-circle {
   width: 2rem;
   height: 2rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
 }
 
 .btn:focus {

--- a/Public/js/app.js
+++ b/Public/js/app.js
@@ -473,9 +473,8 @@ export class App {
             document.getElementById("match-count").textContent = "Timed out";
           } else {
             this.updateMatchCount(0, "match-count");
+            debuggerButton.disabled = true;
           }
-
-          debuggerButton.disabled = true;
         }
 
         this.patternTestEditor.error =
@@ -615,6 +614,8 @@ export class App {
     let display;
     if (value == null) {
       display = `<span style="color:#6c757d;">nil</span>`;
+    } else if (value === "") {
+      display = `<span style="color:#6c757d;">empty string</span>`;
     } else {
       display = App.formatDisplayValue(value);
     }


### PR DESCRIPTION
## Summary
- Show match results list tooltip on match count badge with numbered entries, capture group labels (`.0`, `.year`, `.1`), and whitespace visualization
- Handle grapheme clusters correctly using `Intl.Segmenter`, display labels for invisible Unicode characters (ZWJ, ZWNJ, VS16, etc.)
- Show "empty string" for empty match values in tooltip
- Keep debugger button enabled when match times out but parse succeeds
- Center icons in debugger round buttons via flexbox
- Remove unused `Group.scalars` field and optimize `scalarInfos` to single pass

## Test plan
- [ ] Verify match count badge shows tooltip with numbered match results on hover
- [ ] Verify capture groups display with correct labels (`.0`, named captures like `.year`)
- [ ] Verify emoji/grapheme clusters display correctly without decomposition
- [ ] Verify whitespace characters show editor symbols (␣, ↵, ⇥)
- [ ] Verify empty string matches display "empty string" in tooltip
- [ ] Verify debugger button remains enabled when match times out
- [ ] Verify debugger control button icons are centered in round buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)