### PR TITLE
Force kill timed-out subprocesses with SIGKILL

### DIFF
--- a/Public/js/app.js
+++ b/Public/js/app.js
@@ -475,9 +475,6 @@ export class App {
           this.matchCountTooltip.setContent(
             matches.length ? App.buildMatchListTooltip(matches) : "",
           );
-
-          document.getElementById("debugger-button").disabled =
-            matches.length === 0;
         } else {
           this.patternTestEditor.matches = [];
           this.matchCountTooltip.setContent("");
@@ -485,9 +482,6 @@ export class App {
             document.getElementById("match-count").textContent = "Timed out";
           } else {
             this.updateMatchCount(0, "match-count");
-          }
-          if (response.error && response.error !== "Timed out") {
-            document.getElementById("debugger-button").disabled = true;
           }
         }
 

--- a/Public/js/app.js
+++ b/Public/js/app.js
@@ -476,7 +476,8 @@ export class App {
             matches.length ? App.buildMatchListTooltip(matches) : "",
           );
 
-          debuggerButton.disabled = matches.length === 0;
+          document.getElementById("debugger-button").disabled =
+            matches.length === 0;
         } else {
           this.patternTestEditor.matches = [];
           this.matchCountTooltip.setContent("");

--- a/Sources/App/Debugger/Context.swift
+++ b/Sources/App/Debugger/Context.swift
@@ -7,7 +7,7 @@ extension Debugger {
 
     var stepCount = 0
     var breakPoint: Int?
-    var maxStepCount = 10_000_000
+    var maxStepCount = 1_000_000
 
     var start: Int = 0
     var current: Int = 0

--- a/Sources/App/Debugger/Context.swift
+++ b/Sources/App/Debugger/Context.swift
@@ -7,6 +7,7 @@ extension Debugger {
 
     var stepCount = 0
     var breakPoint: Int?
+    var maxStepCount = 10_000_000
 
     var start: Int = 0
     var current: Int = 0

--- a/Sources/App/Debugger/Executor.swift
+++ b/Sources/App/Debugger/Executor.swift
@@ -158,7 +158,8 @@ extension Processor {
           context.resets = metrics.resets
           context.backtracks = metrics.backtracks
         #endif
-        if context.stepCount == context.breakPoint {
+        if context.stepCount == context.breakPoint ||
+          context.stepCount >= context.maxStepCount {
           throw CancellationError()
         }
       }

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -216,6 +216,12 @@ func routes(_ app: Application) throws {
         if process.isRunning {
           didTimeout = true
           process.terminate()
+          let pid = process.processIdentifier
+          DispatchQueue.global().asyncAfter(deadline: .now() + 1) {
+            if process.isRunning {
+              kill(pid, SIGKILL)
+            }
+          }
         }
       }
       timer.resume()

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -116,12 +116,6 @@ func routes(_ app: Application) throws {
           try run(pattern: pattern, text: text, matchingOptions: matchOptions)
           let stepCount = context.stepCount
 
-          if stepCount >= context.maxStepCount {
-            let response = ResultResponse(method: .debug, result: "", error: "Timed out", id: id)
-            continuation.resume(returning: response)
-            return
-          }
-
           try run(pattern: pattern, text: text, matchingOptions: matchOptions, until: breakPoint)
 
           let metrics = Debugger.Metrics(

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -217,7 +217,7 @@ func routes(_ app: Application) throws {
           didTimeout = true
           process.terminate()
           let pid = process.processIdentifier
-          DispatchQueue.global().asyncAfter(deadline: .now() + 1) {
+          syncQueue.asyncAfter(deadline: .now() + 1) {
             if process.isRunning {
               kill(pid, SIGKILL)
             }

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -116,6 +116,12 @@ func routes(_ app: Application) throws {
           try run(pattern: pattern, text: text, matchingOptions: matchOptions)
           let stepCount = context.stepCount
 
+          if stepCount >= context.maxStepCount {
+            let response = ResultResponse(method: .debug, result: "", error: "Timed out", id: id)
+            continuation.resume(returning: response)
+            return
+          }
+
           try run(pattern: pattern, text: text, matchingOptions: matchOptions, until: breakPoint)
 
           let metrics = Debugger.Metrics(


### PR DESCRIPTION
## Summary
- `process.terminate()` sends SIGTERM, but subprocesses stuck in a CPU-bound regex engine loop do not respond to it
- This causes the Matcher process to leak (running at 100% CPU indefinitely) and the response to never be sent back to the client
- Fall back to SIGKILL after a 1-second grace period if the process is still running after SIGTERM

## Test plan
- [ ] Send a catastrophic backtracking pattern (e.g. `(a+)+$` against `aaaaaaaaaaaaaaaaaaaaaaaaaab`) and verify "Timed out" response is returned within ~6 seconds
- [ ] Verify no zombie Matcher processes remain after timeout (`ps aux` in container)
- [ ] Verify normal matching still works after a timeout occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)