### PR TITLE
Fix debugger cursor height exceeding line height

### DIFF
--- a/Public/js/views/debugger_highlighter.js
+++ b/Public/js/views/debugger_highlighter.js
@@ -13,7 +13,7 @@ class TraceWidget extends WidgetType {
     const span = document.createElement("span");
     span.className = this.className;
     span.style.display = "inline-block";
-    span.style.height = `${view.defaultLineHeight * 1.5}px`;
+    span.style.height = `${view.defaultLineHeight}px`;
     span.style.width = this.useCharWidth
       ? `${view.defaultCharacterWidth}px`
       : "1px";


### PR DESCRIPTION
## Summary
- The debugger trace cursor widget used `defaultLineHeight * 1.5`, making it 50% taller than the line
- This caused lines to expand when the cursor moved into them
- Changed to `defaultLineHeight` so the cursor fits within the normal line height

## Test plan
- [ ] Open the debugger and step through a multi-line test string
- [ ] Verify the cursor (light blue vertical bar) fits within the line without expanding it

🤖 Generated with [Claude Code](https://claude.com/claude-code)